### PR TITLE
Fix/http and log

### DIFF
--- a/commands/serve.v
+++ b/commands/serve.v
@@ -118,7 +118,7 @@ pub fn (mut s ServeCommand) run() ! {
 	}
 	mut server := &http.Server{
 		handler: handler
-		port: commands.cport
+		addr: ':${commands.cport}'
 	}
 
 	// base_url を localhost にする

--- a/main.v
+++ b/main.v
@@ -16,10 +16,10 @@ fn load_config(toml_file string) !config.Config {
 	return config.load(toml_text)
 }
 
-fn init_logger() log.Log {
-	return log.Log{
-		level: log.Level.info
-	}
+fn init_logger() &log.Log {
+    mut l := log.Log{}
+    l.set_level(.info)
+    return &l
 }
 
 fn init_commands() cli.Command {

--- a/main.v
+++ b/main.v
@@ -17,9 +17,9 @@ fn load_config(toml_file string) !config.Config {
 }
 
 fn init_logger() &log.Log {
-    mut l := log.Log{}
-    l.set_level(.info)
-    return &l
+	mut l := log.Log{}
+	l.set_level(.info)
+	return &l
 }
 
 fn init_commands() cli.Command {


### PR DESCRIPTION
I was having this couple of errors:

Running in macos / macbook air m3
and v version: `V 0.4.7 7baff15`.

```
v run .
commands/serve.v:121:3: warning: field `port` has been deprecated; use addr
  119 |     mut server := &http.Server{
  120 |         handler: handler
  121 |         port: commands.cport
      |         ~~~~~~~~~~~~~~~~~~~~
  122 |     }
  123 |
main.v:21:3: error: cannot access private field `level` on `log.Log`
   19 | fn init_logger() log.Log {
   20 |     return log.Log{
   21 |         level: log.Level.info
      |         ~~~~~~~~~~~~~~~~~~~~~
   22 |     }
   23 | }
```

Here are the fixes I did to make it work in my local.